### PR TITLE
Remove Clang3.8 from the build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,16 +20,17 @@ matrix:
                       - r-packages-precise
                       - llvm-toolchain-precise
                       - ubuntu-toolchain-r-test
-        - language: python
-          python: "3.5"
-          env: CXX=clang++-3.8 CC=clang-3.8
-          addons:
-              apt:
-                  packages:
-                      - clang-3.8
-                      - libicu-dev
-                      - ninja-build
-                  sources: *sources
+# This was failing builds (see for example https://travis-ci.org/LoungeCPP/Tatsoryk/jobs/119365368)
+#        - language: python
+#          python: "3.5"
+#          env: CXX=clang++-3.8 CC=clang-3.8
+#          addons:
+#              apt:
+#                  packages:
+#                      - clang-3.8
+#                      - libicu-dev
+#                      - ninja-build
+#                  sources: *sources
 
 install:
     - if [ -n "$CXX" ]; then


### PR DESCRIPTION
Apparently the package is missing the binaries?
See https://travis-ci.org/LoungeCPP/Tatsoryk/jobs/119365368 for a fail
example

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/loungecpp/tatsoryk/19)

<!-- Reviewable:end -->
